### PR TITLE
Fix normalize_uri to remove options specified in "keys" from "query"

### DIFF
--- a/lib/dm-do-adapter/adapter.rb
+++ b/lib/dm-do-adapter/adapter.rb
@@ -220,9 +220,9 @@ module DataMapper
         @normalized_uri ||=
           begin
             keys = [
-              :adapter, :user, :password, :host, :port, :path, :fragment,
-              :scheme, :query, :username, :database ]
-            query = DataMapper::Ext::Hash.except(@options, keys)
+              "adapter", "user", "password", "host", "port", "path", "fragment",
+              "scheme", "query", "username", "database" ]
+            query = DataMapper::Ext::Hash.except(@options, *keys)
             query = nil if query.empty?
 
             # Better error message in case port is no Numeric value


### PR DESCRIPTION
There was a small problem in normalize_uri that was causing it so that SQLServer connections wouldn't work.  normalize_uri had code in it that was meant to remove specified options before building "query", but a combination of things meant that it was silently failing - DataMapper::Ext::Hash.except expects the second parameter to be *expanded or a variable length argument list and the @options are string keyed, not symbols keyed and "keys" was an array of symbols.

This doesn't seem to be important to other databases, but SQLServer was giving a "DataObjects::SQLError: Can't connect". Other databases must just ignore the extra query parameters.
