### PR TITLE
Log cleaner in specs was only removing time information with "." seperator

### DIFF
--- a/lib/dm-do-adapter/spec/shared_spec.rb
+++ b/lib/dm-do-adapter/spec/shared_spec.rb
@@ -31,7 +31,7 @@ share_examples_for 'A DataObjects Adapter' do
     @log.rewind
     output = @log.read
     output.chomp!
-    output.gsub!(/\A\s+~ \(\d+\.?\d*\)\s+/, '')
+    output.gsub!(/\A\s+~ \(\d+[\.,]?\d*\)\s+/, '')
     output.gsub!(/\Acom\.\w+\.jdbc\.JDBC4PreparedStatement@[^:]+:\s+/, '') if @jruby
     output.split($/)
   end


### PR DESCRIPTION
This patch will remove time prefixes (like " ~ (0,1234) ") in logged SQL statements with locales using  "," instead of "." as separator too
