### PR TITLE
sometimes normalized_uri was generating wrong uri

### DIFF
--- a/lib/dm-do-adapter/adapter.rb
+++ b/lib/dm-do-adapter/adapter.rb
@@ -229,7 +229,7 @@ module DataMapper
             port = @options[:port].nil? ? nil : @options[:port].to_int
 
             DataObjects::URI.new(
-              :scheme     => @options[:adapter],
+              :scheme     => @options[:scheme] || @options[:adapter],
               :user       => @options[:user] || @options[:username],
               :password   => @options[:password],
               :host       => @options[:host],

--- a/lib/dm-do-adapter/adapter.rb
+++ b/lib/dm-do-adapter/adapter.rb
@@ -266,7 +266,7 @@ module DataMapper
         super
 
         # Default the driver-specific logger to DataMapper's logger
-        if driver_module = DataObjects.const_get(normalized_uri.scheme.capitalize)
+        if driver_module = DataObjects.adapter_name(normalized_uri)
           driver_module.logger = DataMapper.logger if driver_module.respond_to?(:logger=)
         end
       end


### PR DESCRIPTION
if adapter is not there, or different from schema, normailized_uri was generating a wrong uri.

should use schema if it's there.
