### PR TITLE
Change comparison operator based on inclusive vs exclusive ranges

### DIFF
--- a/lib/dm-do-adapter/adapter.rb
+++ b/lib/dm-do-adapter/adapter.rb
@@ -677,10 +677,11 @@ module DataMapper
           # update conditions_statement to use it
 
           # break exclusive Range queries up into two comparisons ANDed together
-          if value.kind_of?(Range) && value.exclude_end?
+          if value.kind_of?(Range)
+            comparator = value.exclude_end? ? :lt : :lte
             operation = Query::Conditions::Operation.new(:and,
               Query::Conditions::Comparison.new(:gte, subject, value.first),
-              Query::Conditions::Comparison.new(:lt,  subject, value.last)
+              Query::Conditions::Comparison.new(comparator, subject, value.last)
             )
 
             statement, bind_values = conditions_statement(operation, qualify)

--- a/lib/dm-do-adapter/spec/shared_spec.rb
+++ b/lib/dm-do-adapter/spec/shared_spec.rb
@@ -396,6 +396,28 @@ share_examples_for 'A DataObjects Adapter' do
         end
       end
 
+      context 'with an range with inclusive end' do
+        before :all do
+          5.times do |index|
+            @article_model.create(:name => "Test #{index}", :parent => @article_model.last).should be_saved
+          end
+        end
+
+        it 'should not call #partition on the range' do
+          range = 1..5
+
+          query = DataMapper::Query.new(repository, @article_model, :parent_name => range)
+
+          # We have to get the dumped value, because the original value has been
+          # dupped multiple times
+          val = query.conditions.operands.first.send(:dumped_value)
+          val.stub(:partition)
+          val.should_not_receive(:partition)
+
+          @adapter.read(query)
+        end
+      end
+
       context 'with an inclusion comparison of nil values' do
         before :all do
           5.times do |index|


### PR DESCRIPTION
When a Range with in inclusive end was used, the entire Range would be partitioned. This is not necessary, because only the first and the last item of the Range are important.

This could result in poor performance when using big ranges.

The fix just changes the comparison operator based on whether the range is inclusive or exclusive.
